### PR TITLE
Toggle settings pane with jQuery

### DIFF
--- a/hackIDE/static/hackIDE/js/custom.js
+++ b/hackIDE/static/hackIDE/js/custom.js
@@ -404,20 +404,7 @@ $(document).ready(function(){
 
 	// when show-settings is clicked
 	$("#show-settings").click(function(){
-
-		if(settingsPaneVisible){
-			// hide settings-pane
-			$("#settings-pane").hide();
-			// update flag
-			settingsPaneVisible = false;
-		}
-		else{
-			// hide settings-pane
-			$("#settings-pane").show();
-			// update flag
-			settingsPaneVisible = true;
-		}
-
+			$("#settings-pane").toggle();  // toggle visibility of the pane
 	});
 
 


### PR DESCRIPTION
## Work done
- Instead of using custom logics to keep track if the settings pane is opened, use .toggle instead to perform show or hide.