### PR TITLE
Allow setting DEBUG from command line

### DIFF
--- a/hackIDE_project/settings.py
+++ b/hackIDE_project/settings.py
@@ -23,9 +23,9 @@ print BASE_DIR
 SECRET_KEY = '+h*i@$52+w(_e#etvzgnkjq!q0ajz1qpgs-y9%89x4w3nlct=m'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = (os.environ.get('HACKIDE_DEBUG') or "").lower() == "true"
 
-ALLOWED_HOSTS = ['hackide.herokuapp.com']
+ALLOWED_HOSTS = ['hackide.herokuapp.com'] if not DEBUG else ['*']
 
 # To allow the cross site request over the app
 CORS_ORIGIN_ALLOW_ALL = True


### PR DESCRIPTION
Set DEBUG from command line. If not set, defaults to False.

Update ALLOWED_HOSTS accordingly.