### PR TITLE
Settings drop-down menu bug fix

### DIFF
--- a/hackIDE/static/hackIDE/js/custom.js
+++ b/hackIDE/static/hackIDE/js/custom.js
@@ -480,7 +480,6 @@ $(document).ready(function(){
 
 
 	// when show-settings is clicked
-	var clicked = false;
 	$("#show-settings").click(function(event){
 
 		event.stopPropagation();

--- a/hackIDE/static/hackIDE/js/custom.js
+++ b/hackIDE/static/hackIDE/js/custom.js
@@ -480,11 +480,22 @@ $(document).ready(function(){
 
 
 	// when show-settings is clicked
-	$("#show-settings").click(function(){
+	var clicked = false;
+	$("#show-settings").click(function(event){
 
+		event.stopPropagation();
+		
 		// toggle visibility of the pane
 		$("#settings-pane").toggle();
 
+	});
+
+
+	//close settings dropdown
+	$(function(){
+		$(document).click(function(){
+			$('#settings-pane').hide();
+		});
 	});
 
 


### PR DESCRIPTION
In the last fix, a little bug was left unnoticed. The settings-menu would hide by clicking anywhere but on itself. You can check that.